### PR TITLE
Implement background layer functionality

### DIFF
--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -31,18 +31,15 @@ export class Export
                 if (path.blendMode === "add") { //ignore eraser paths
                     path.blendMode = "subtract";
                     backgroundLayer.addPathToLayer(path);
-                    backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
-                    path.blendMode = "add";
                 }
             });
             this.layers[i].shapes.forEach(function(shape) {
                 if (shape.blendMode === "add") { //ignore eraser paths
                     shape.blendMode = "subtract";
                     backgroundLayer.addShapeToLayer(shape);
-                    backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
-                    shape.blendMode = "add";
                 }
             });
+            backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
         }
         this.layers.push(backgroundLayer);
     }

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -31,15 +31,18 @@ export class Export
                 if (path.blendMode === "add") { //ignore eraser paths
                     path.blendMode = "subtract";
                     backgroundLayer.addPathToLayer(path);
+                    backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
+                    path.blendMode = "add";
                 }
             });
             this.layers[i].shapes.forEach(function(shape) {
                 if (shape.blendMode === "add") { //ignore eraser paths
                     shape.blendMode = "subtract";
-                    backgroundLayer.addShapeToLayer();
+                    backgroundLayer.addShapeToLayer(shape);
+                    backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
+                    shape.blendMode = "add";
                 }
             });
-            backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
         }
         this.layers.push(backgroundLayer);
     }

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -26,17 +26,18 @@ export class Export
         let rect = new Rectangle(new Point(0, 0, this.pageIndex), 10000, 10000, "add");
         backgroundLayer.addShapeToLayer(rect);
         backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
-        for (var i = 0; i < this.layers.length; i++) {
+        for (var i = 0; i < this.layers.length; i++) { 
+            this.layers[i].shapes.forEach(function(shape) { //shapes first
+                shape.blendMode = "subtract";
+                backgroundLayer.addShapeToLayer(shape);
+            });
             this.layers[i].paths.forEach(function(path) {
                 if (path.blendMode === "add") { //ignore eraser paths
                     path.blendMode = "subtract";
                     backgroundLayer.addPathToLayer(path);
-                }
-            });
-            this.layers[i].shapes.forEach(function(shape) {
-                if (shape.blendMode === "add") { //ignore eraser paths
-                    shape.blendMode = "subtract";
-                    backgroundLayer.addShapeToLayer(shape);
+                } else {
+                    path.blendMode = "add";
+                    backgroundLayer.addPathToLayer(path);
                 }
             });
             backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -21,7 +21,7 @@ export class Export
 
     createBackgroundLayer() {
         //Create new background layer which is the actual background
-        let backgroundLayer = new Layer(4, new Colour(242, 0, 242, 1), "RealBackground", this.pixelInstance, 0.5, this.pixelInstance.actions);
+        let backgroundLayer = new Layer(4, new Colour(242, 0, 242, 1), "Background Layer", this.pixelInstance, 0.5, this.pixelInstance.actions);
         //Select everything on backgroundLayer using a large rectangle
         let rect = new Rectangle(new Point(0, 0, this.pageIndex), 10000, 10000, "add");
         backgroundLayer.addShapeToLayer(rect);

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -98,7 +98,7 @@ export class Export
                     console.log(urlList);
                     console.log("done");
 
-                    $.ajax({url: '', type: 'POST', data: JSON.stringify({'user_input': urlList}), contentType: 'application/json'});
+                    $.ajax({url: '', type: 'POST', data: JSON.stringify({   'user_input': urlList}), contentType: 'application/json'});
                 }
         });
     }
@@ -110,6 +110,14 @@ export class Export
     exportLayersAsHighlights ()
     {
         console.log("Exporting");
+
+        let backgroundLayer = new Layer(4, new Colour(242, 242, 242, 1), "RealBackground", pixelInstance, 0.5, pixelInstance.actions);
+        backgroundLayer = pixelInstance.background;
+        for (var i = 0; i < this.layers.length; i++) 
+        {
+            backgroundLayer.addPathToLayer(layers[i].getCurrentPath());
+        }
+        this.layers.push(backgroundLayer);
 
         // The idea here is to draw each layer on a canvas and scan the pixels of that canvas to fill the matrix
         this.layers.forEach((layer) => {

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -1,5 +1,8 @@
 import {Colour} from './colour';
 import {Point} from './point';
+import {Layer} from './layer';
+import {Rectangle} from './rectangle';
+import {Selection} from './selection';
 
 export class Export
 {
@@ -109,13 +112,20 @@ export class Export
 
     exportLayersAsHighlights ()
     {
-        console.log("Exporting");
+        console.log("Exporting 123");
 
-        let backgroundLayer = new Layer(4, new Colour(242, 242, 242, 1), "RealBackground", pixelInstance, 0.5, pixelInstance.actions);
-        backgroundLayer = pixelInstance.background;
-        for (var i = 0; i < this.layers.length; i++) 
-        {
-            backgroundLayer.addPathToLayer(layers[i].getCurrentPath());
+        //Create new background layer which is the actual background
+        let backgroundLayer = new Layer(4, new Colour(242, 0, 242, 1), "RealBackground", this.pixelInstance, 0.5, this.pixelInstance.actions);
+        //Select everything on backgroundLayer using a large rectangle
+        let rect = new Rectangle(new Point(0, 0, this.pageIndex), 10000, 10000, "add");
+        backgroundLayer.addShapeToLayer(rect);
+        backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
+        //rect.drawOnPage(backgroundLayer, this.pageIndex, this.zoomLevel, this.pixelInstance.core.getSettings().renderer, backgroundLayer.getCanvas());
+        for (var i = 1; i < this.layers.length; i++) {
+            let layerSelection = new Selection();
+            layerSelection.setSelectedShape(rect, this.layers[i]);
+            backgroundLayer.removeSelectionFromLayer(layerSelection);
+            backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
         }
         this.layers.push(backgroundLayer);
 

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -121,10 +121,19 @@ export class Export
         backgroundLayer.addShapeToLayer(rect);
         backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
         //rect.drawOnPage(backgroundLayer, this.pageIndex, this.zoomLevel, this.pixelInstance.core.getSettings().renderer, backgroundLayer.getCanvas());
-        for (var i = 1; i < this.layers.length; i++) {
-            let layerSelection = new Selection();
-            layerSelection.setSelectedShape(rect, this.layers[i]);
-            backgroundLayer.removeSelectionFromLayer(layerSelection);
+        for (var i = 0; i < this.layers.length; i++) {
+            this.layers[i].paths.forEach(function(path) {
+                if (path.blendMode === "add") { //ignore eraser paths
+                    path.blendMode = "subtract";
+                    backgroundLayer.addPathToLayer(path);
+                }
+            });
+            this.layers[i].shapes.forEach(function(shape) {
+                if (shape.blendMode === "add") { //ignore eraser paths
+                    shape.blendMode = "subtract";
+                    backgroundLayer.addShapeToLayer(shape);
+                }
+            });
             backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
         }
         this.layers.push(backgroundLayer);


### PR DESCRIPTION
Takes the difference of the other 3 layers and generates a new layer when exporting. NOTE: can only be done once (ie. if you export to PNG, cannot export to imagedata, outcome won't be as intended).
But, since we expect the user to only `export to Rodan`, it shouldn't be an issue

The only file changed is export.js, but I had to do some imports in order to restrain all the code to just export (this way the background is only generated when exporting, don't want the user to be able to alter the background layer while editing).
