### PR TITLE
Background layer

### DIFF
--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -3,7 +3,6 @@ import {Point} from './point';
 import {Layer} from './layer';
 import {Rectangle} from './rectangle';
 import {Path} from './path';
-import {Shape} from './shape';
 
 export class Export
 {
@@ -35,13 +34,12 @@ export class Export
         //Loop through each layer and add all their paths to the background in the opposite mode
         for (var i = 0; i < this.layers.length; i++) { 
             this.layers[i].shapes.forEach(function(shape) { //Shapes get deleted first so eraser paths can be readded after
-                //make a copy of shape
-                var newShape = new Shape(shape.point, shape.blendMode);
-                newShape.blendMode = "subtract";
+                //make a clone of shape
+                var newShape = new Rectangle(shape.origin, shape.relativeRectWidth, shape.relativeRectHeight, "subtract");
                 backgroundLayer.addShapeToLayer(newShape);
             });
             this.layers[i].paths.forEach(function(path) {
-                //make a copy of path
+                //make a clone of path
                 var newPath = new Path(path.brushSize, path.blendMode);
                 newPath.points = path.points.slice();
                 newPath.lastAbsX = path.lastAbsX;
@@ -145,7 +143,7 @@ export class Export
                     console.log(urlList);
                     console.log("done");
 
-                    $.ajax({url: '', type: 'POST', data: JSON.stringify({   'user_input': urlList}), contentType: 'application/json'});
+                    $.ajax({url: '', type: 'POST', data: JSON.stringify({'user_input': urlList}), contentType: 'application/json'});
                 }
         });
     }

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -98,7 +98,7 @@ export class Export
                     console.log(urlList);
                     console.log("done");
 
-                    $.ajax({url: '', type: 'POST', data: JSON.stringify({'user_input': urlList}), contentType: 'application/json'});
+                    $.ajax({url: '', type: 'POST', data: JSON.stringify({   'user_input': urlList}), contentType: 'application/json'});
                 }
         });
     }
@@ -110,6 +110,14 @@ export class Export
     exportLayersAsHighlights ()
     {
         console.log("Exporting");
+
+        let backgroundLayer = new Layer(4, new Colour(242, 242, 242, 1), "RealBackground", pixelInstance, 0.5, pixelInstance.actions);
+        backgroundLayer = pixelInstance.background;
+        for (var i = 0; i < this.layers.length; i++) 
+        {
+            backgroundLayer.addPathToLayer(layers[i].getCurrentPath());
+        }
+        this.layers.push(backgroundLayer);
 
         // The idea here is to draw each layer on a canvas and scan the pixels of that canvas to fill the matrix
         this.layers.forEach((layer) => {

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -1,5 +1,8 @@
 import {Colour} from './colour';
 import {Point} from './point';
+import {Layer} from './layer';
+import {Rectangle} from './rectangle';
+import {Selection} from './selection';
 
 export class Export
 {
@@ -109,13 +112,20 @@ export class Export
 
     exportLayersAsHighlights ()
     {
-        console.log("Exporting");
+        console.log("Exporting 123");
 
-        let backgroundLayer = new Layer(4, new Colour(242, 242, 242, 1), "RealBackground", pixelInstance, 0.5, pixelInstance.actions);
-        backgroundLayer = pixelInstance.background;
-        for (var i = 0; i < this.layers.length; i++) 
-        {
-            backgroundLayer.addPathToLayer(layers[i].getCurrentPath());
+        //Create new background layer which is the actual background
+        let backgroundLayer = new Layer(4, new Colour(242, 0, 242, 1), "RealBackground", this.pixelInstance, 0.5, this.pixelInstance.actions);
+        //Select everything on backgroundLayer using a large rectangle
+        let rect = new Rectangle(new Point(0, 0, this.pageIndex), 10000, 10000, "add");
+        backgroundLayer.addShapeToLayer(rect);
+        backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
+        //rect.drawOnPage(backgroundLayer, this.pageIndex, this.zoomLevel, this.pixelInstance.core.getSettings().renderer, backgroundLayer.getCanvas());
+        for (var i = 1; i < this.layers.length; i++) {
+            let layerSelection = new Selection();
+            layerSelection.setSelectedShape(rect, this.layers[i]);
+            backgroundLayer.removeSelectionFromLayer(layerSelection);
+            backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
         }
         this.layers.push(backgroundLayer);
 

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -121,10 +121,19 @@ export class Export
         backgroundLayer.addShapeToLayer(rect);
         backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
         //rect.drawOnPage(backgroundLayer, this.pageIndex, this.zoomLevel, this.pixelInstance.core.getSettings().renderer, backgroundLayer.getCanvas());
-        for (var i = 1; i < this.layers.length; i++) {
-            let layerSelection = new Selection();
-            layerSelection.setSelectedShape(rect, this.layers[i]);
-            backgroundLayer.removeSelectionFromLayer(layerSelection);
+        for (var i = 0; i < this.layers.length; i++) {
+            this.layers[i].paths.forEach(function(path) {
+                if (path.blendMode === "add") { //ignore eraser paths
+                    path.blendMode = "subtract";
+                    backgroundLayer.addPathToLayer(path);
+                }
+            });
+            this.layers[i].shapes.forEach(function(shape) {
+                if (shape.blendMode === "add") { //ignore eraser paths
+                    shape.blendMode = "subtract";
+                    backgroundLayer.addShapeToLayer(shape);
+                }
+            });
             backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
         }
         this.layers.push(backgroundLayer);

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -21,22 +21,23 @@ export class Export
 
     createBackgroundLayer() {
         //Create new background layer which is the actual background
-        let backgroundLayer = new Layer(4, new Colour(242, 0, 242, 1), "RealBackground", this.pixelInstance, 0.5, this.pixelInstance.actions);
+        let backgroundLayer = new Layer(4, new Colour(242, 0, 242, 1), "Background Layer", this.pixelInstance, 0.5, this.pixelInstance.actions);
         //Select everything on backgroundLayer using a large rectangle
         let rect = new Rectangle(new Point(0, 0, this.pageIndex), 10000, 10000, "add");
         backgroundLayer.addShapeToLayer(rect);
         backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());
-        for (var i = 0; i < this.layers.length; i++) {
+        for (var i = 0; i < this.layers.length; i++) { 
+            this.layers[i].shapes.forEach(function(shape) { //shapes first
+                shape.blendMode = "subtract";
+                backgroundLayer.addShapeToLayer(shape);
+            });
             this.layers[i].paths.forEach(function(path) {
                 if (path.blendMode === "add") { //ignore eraser paths
                     path.blendMode = "subtract";
                     backgroundLayer.addPathToLayer(path);
-                }
-            });
-            this.layers[i].shapes.forEach(function(shape) {
-                if (shape.blendMode === "add") { //ignore eraser paths
-                    shape.blendMode = "subtract";
-                    backgroundLayer.addShapeToLayer();
+                } else {
+                    path.blendMode = "add";
+                    backgroundLayer.addPathToLayer(path);
                 }
             });
             backgroundLayer.drawLayer(this.pixelInstance.core.getSettings().maxZoomLevel, backgroundLayer.getCanvas());

--- a/wrapper.py
+++ b/wrapper.py
@@ -156,6 +156,13 @@ class PixelInteractive(RodanTask):
             'maximum': 1,
             'is_list': False
         },
+        {
+            'name': 'rgba PNG - Layer 4 Output',
+            'resource_types': ['image/rgba+png'],
+            'minimum': 1,
+            'maximum': 1,
+            'is_list': False
+        },
     ]
 
     def get_my_interface(self, inputs, settings):


### PR DESCRIPTION
- Implement background layer functionality in Pixel, when exporting to any filetype (or to Rodan) an additional background layer will be created which contains the negative of the 3 other layers. 
- There is 1 known bug, which is if the user tries to erase another layer than the one they are currently on, the background layer will treat it like a normal erase (so erases that do nothing visually actually affect the background layer). 
  - However, since this only affects the background layer generation and only in a specific case, and the rest of the functionality of Pixel works the same, perhaps it is okay to merge?