### PR TITLE
Add background button w/ progress bar, and generalize variable values to any number of layers

### DIFF
--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -16,23 +16,25 @@ export class Export
         this.zoomLevel = zoomLevel;
         this.matrix = null;
         this.uiManager = uiManager;
-        this.layersCount = 3;
+        this.layersCount = layers.length; // For generating the background layer, excludes background
     }
 
     /**
      *  Generates a background layer by iterating over all the pixel data for each layer and 
      *  subtracting it from the background layer if the data is non-transparent (alpha != 0). Somewhat
-     *  replicates what the exportLayersAsImageData function does but for the background.
+     *  replicates what the exportLayersAsImageData function does but for generating the background
+     *  layer, and there are numerous (albeit small) differences that requires a new function
      */
     createBackgroundLayer () 
     {
         // If generate background button has already been clicked, remove that background layer from layers
-        if (this.layers.length === 4) { 
+        if (document.getElementById("create-background-button").innerText === "Background Generated!") { 
             this.layers.pop();
+            this.layersCount = this.layers.length;
         }
 
-        let backgroundLayer = new Layer(4, new Colour(242, 0, 242, 1), "Background Layer", this.pixelInstance, 0.5, 
-            this.pixelInstance.actions),
+        let backgroundLayer = new Layer(this.layersCount+1, new Colour(242, 0, 242, 1), "Background Layer", 
+            this.pixelInstance, 0.5, this.pixelInstance.actions),
             maxZoom = this.pixelInstance.core.getSettings().maxZoomLevel,
             pageIndex = this.pageIndex,
             width = this.pixelInstance.core.publicInstance.getPageDimensionsAtZoomLevel(pageIndex, maxZoom).width,
@@ -43,7 +45,7 @@ export class Export
         backgroundLayer.addShapeToLayer(rect);
         backgroundLayer.drawLayer(maxZoom, backgroundLayer.getCanvas());
 
-        // Instantiate 
+        // Instantiate progress bar
         this.uiManager.createExportElements(this);
 
         this.layers.forEach((layer) => {

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -24,10 +24,12 @@ export class Export
      */
     createBackgroundLayer() 
     {
-        //If export button has already been clicked, remove that background layer from layers
+        console.log("Generating...");
+        //If generate background button has already been clicked, remove that background layer from layers
         if (this.layers.length === 4) { 
             this.layers.pop();
         }
+
         let backgroundLayer = new Layer(4, new Colour(242, 0, 242, 1), "Background Layer", this.pixelInstance, 0.5, 
             this.pixelInstance.actions),
             maxZoom = this.pixelInstance.core.getSettings().maxZoomLevel,
@@ -41,7 +43,6 @@ export class Export
         backgroundLayer.drawLayer(maxZoom, backgroundLayer.getCanvas());
 
         this.layers.forEach(function(layer) {
-
             //create canvas to retrieve pixel data through context
             let layerCanvas = document.createElement('canvas');
             layerCanvas.setAttribute("class", "export-page-canvas");
@@ -63,13 +64,14 @@ export class Export
                     }
                 }
                 if (row === height-1) {
-                    console.log("Done layer " + layer.layerId);
+                    console.log(layer.layerId*33 + "% done");
                 }
             }
             backgroundLayer.drawLayer(0, backgroundLayer.getCanvas());
         });
         this.layers.push(backgroundLayer);  
-        console.log("Done exporting");
+        document.getElementById("create-background-button").innerText = "Generated!";
+        console.log("Generated");
     }
 
     /**
@@ -79,8 +81,6 @@ export class Export
     exportLayersAsImageData ()
     {
         this.dataCanvases = [];
-
-        this.createBackgroundLayer();
 
         let height = this.pixelInstance.core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).height,
             width = this.pixelInstance.core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).width;
@@ -142,8 +142,6 @@ export class Export
     {
         console.log("Exporting");
 
-        this.createBackgroundLayer();
-
         let count = this.layers.length;
         let urlList = [];
 
@@ -170,8 +168,6 @@ export class Export
     exportLayersAsHighlights ()
     {
         console.log("Exporting");
-
-        this.createBackgroundLayer();
 
         // The idea here is to draw each layer on a canvas and scan the pixels of that canvas to fill the matrix
         this.layers.forEach((layer) => {

--- a/source/js/plugins/Pixel.js/source/pixel.js
+++ b/source/js/plugins/Pixel.js/source/pixel.js
@@ -1115,8 +1115,6 @@ export default class PixelPlugin
      * ===============================================
      **/
 
-    // Will fill a canvas with the highlighted data and scan every pixel of that and fill another canvas with diva data
-    // on the highlighted regions
     createBackgroundLayer ()
     {
         let pageIndex = this.core.getSettings().currentPageIndex,
@@ -1124,7 +1122,9 @@ export default class PixelPlugin
 
         new Export(this, this.layers, pageIndex, zoomLevel, this.uiManager).createBackgroundLayer();
     }
-
+    
+    // Will fill a canvas with the highlighted data and scan every pixel of that and fill another canvas with diva data
+    // on the highlighted regions
     exportAsImageData ()
     {
         //FIXME: Force Diva to highest zoom level to be able to get the pixel data

--- a/source/js/plugins/Pixel.js/source/pixel.js
+++ b/source/js/plugins/Pixel.js/source/pixel.js
@@ -1117,6 +1117,14 @@ export default class PixelPlugin
 
     // Will fill a canvas with the highlighted data and scan every pixel of that and fill another canvas with diva data
     // on the highlighted regions
+    createBackgroundLayer ()
+    {
+        let pageIndex = this.core.getSettings().currentPageIndex,
+            zoomLevel = this.core.getSettings().zoomLevel;
+
+        new Export(this, this.layers, pageIndex, zoomLevel, this.uiManager).createBackgroundLayer();
+    }
+
     exportAsImageData ()
     {
         //FIXME: Force Diva to highest zoom level to be able to get the pixel data

--- a/source/js/plugins/Pixel.js/source/ui-manager.js
+++ b/source/js/plugins/Pixel.js/source/ui-manager.js
@@ -538,7 +538,7 @@ export class UIManager
     createExportElements (exportInstance)
     {
         let exportDiv = document.createElement('div'),
-            text = document.createTextNode("Exporting"),
+            text = document.createTextNode("Generating"),
             progressText = document.createTextNode("0%"),
             progressBarOuterDiv = document.createElement('div'),
             progressBarInnerDiv = document.createElement('div'),

--- a/source/js/plugins/Pixel.js/source/ui-manager.js
+++ b/source/js/plugins/Pixel.js/source/ui-manager.js
@@ -445,7 +445,9 @@ export class UIManager
 
     createExportButtons ()
     {
-        let csvExportButton = document.createElement("button"),
+        let createBackgroundButton = document.createElement("button"),
+            createBackgroundText = document.createTextNode("Generate Background Layer"),
+            csvExportButton = document.createElement("button"),
             csvExportText = document.createTextNode("Export as CSV"),
             pngExportButton = document.createElement("button"),
             pngExportText = document.createTextNode("Export as highlights PNG"),
@@ -454,10 +456,15 @@ export class UIManager
             pngDataExportButton = document.createElement("button"),
             pngDataExportText = document.createTextNode("Export as image Data PNG");
 
+        this.createBackgroundLayer = () => { this.pixelInstance.createBackgroundLayer(); };
         this.exportCSV = () => { this.pixelInstance.exportAsCSV(); };
         this.exportPNG = () => { this.pixelInstance.exportAsHighlights(); };
         this.exportToRodan = () => { this.pixelInstance.exportToRodan(); };
         this.exportPNGData = () => { this.pixelInstance.exportAsImageData(); };
+
+        createBackgroundButton.setAttribute("id", "create-background-button");
+        createBackgroundButton.appendChild(createBackgroundText);
+        createBackgroundButton.addEventListener("click", this.createBackgroundLayer);
 
         csvExportButton.setAttribute("id", "csv-export-button");
         csvExportButton.appendChild(csvExportText);
@@ -475,6 +482,7 @@ export class UIManager
         pngDataExportButton.appendChild(pngDataExportText);
         pngDataExportButton.addEventListener("click", this.exportPNGData);
 
+        document.body.appendChild(createBackgroundButton);
         document.body.appendChild(csvExportButton);
         document.body.appendChild(pngExportButton);
         document.body.appendChild(rodanExportButton);

--- a/static/js/pixel.js
+++ b/static/js/pixel.js
@@ -1076,6 +1076,14 @@
 	        // on the highlighted regions
 
 	    }, {
+	        key: 'createBackgroundLayer',
+	        value: function createBackgroundLayer() {
+	            var pageIndex = this.core.getSettings().currentPageIndex,
+	                zoomLevel = this.core.getSettings().zoomLevel;
+
+	            new _export.Export(this, this.layers, pageIndex, zoomLevel, this.uiManager).createBackgroundLayer();
+	        }
+	    }, {
 	        key: 'exportAsImageData',
 	        value: function exportAsImageData() {
 	            //FIXME: Force Diva to highest zoom level to be able to get the pixel data
@@ -2290,10 +2298,12 @@
 	    _createClass(Export, [{
 	        key: 'createBackgroundLayer',
 	        value: function createBackgroundLayer() {
-	            //If export button has already been clicked, remove that background layer from layers
+	            console.log("Generating...");
+	            //If generate background button has already been clicked, remove that background layer from layers
 	            if (this.layers.length === 4) {
 	                this.layers.pop();
 	            }
+
 	            var backgroundLayer = new _layer.Layer(4, new _colour.Colour(242, 0, 242, 1), "Background Layer", this.pixelInstance, 0.5, this.pixelInstance.actions),
 	                maxZoom = this.pixelInstance.core.getSettings().maxZoomLevel,
 	                pageIndex = this.pageIndex,
@@ -2306,7 +2316,6 @@
 	            backgroundLayer.drawLayer(maxZoom, backgroundLayer.getCanvas());
 
 	            this.layers.forEach(function (layer) {
-
 	                //create canvas to retrieve pixel data through context
 	                var layerCanvas = document.createElement('canvas');
 	                layerCanvas.setAttribute("class", "export-page-canvas");
@@ -2328,13 +2337,14 @@
 	                        }
 	                    }
 	                    if (row === height - 1) {
-	                        console.log("Done layer " + layer.layerId);
+	                        console.log(layer.layerId * 33 + "% done");
 	                    }
 	                }
 	                backgroundLayer.drawLayer(0, backgroundLayer.getCanvas());
 	            });
 	            this.layers.push(backgroundLayer);
-	            console.log("Done exporting");
+	            document.getElementById("create-background-button").innerText = "Generated!";
+	            console.log("Generated");
 	        }
 
 	        /**
@@ -2348,8 +2358,6 @@
 	            var _this = this;
 
 	            this.dataCanvases = [];
-
-	            this.createBackgroundLayer();
 
 	            var height = this.pixelInstance.core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).height,
 	                width = this.pixelInstance.core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).width;
@@ -2415,8 +2423,6 @@
 	        value: function exportLayersToRodan() {
 	            console.log("Exporting");
 
-	            this.createBackgroundLayer();
-
 	            var count = this.layers.length;
 	            var urlList = [];
 
@@ -2443,8 +2449,6 @@
 	        key: 'exportLayersAsHighlights',
 	        value: function exportLayersAsHighlights() {
 	            console.log("Exporting");
-
-	            this.createBackgroundLayer();
 
 	            // The idea here is to draw each layer on a canvas and scan the pixels of that canvas to fill the matrix
 	            this.layers.forEach(function (layer) {
@@ -3225,7 +3229,9 @@
 	        value: function createExportButtons() {
 	            var _this8 = this;
 
-	            var csvExportButton = document.createElement("button"),
+	            var createBackgroundButton = document.createElement("button"),
+	                createBackgroundText = document.createTextNode("Generate Background Layer"),
+	                csvExportButton = document.createElement("button"),
 	                csvExportText = document.createTextNode("Export as CSV"),
 	                pngExportButton = document.createElement("button"),
 	                pngExportText = document.createTextNode("Export as highlights PNG"),
@@ -3234,6 +3240,9 @@
 	                pngDataExportButton = document.createElement("button"),
 	                pngDataExportText = document.createTextNode("Export as image Data PNG");
 
+	            this.createBackgroundLayer = function () {
+	                _this8.pixelInstance.createBackgroundLayer();
+	            };
 	            this.exportCSV = function () {
 	                _this8.pixelInstance.exportAsCSV();
 	            };
@@ -3246,6 +3255,10 @@
 	            this.exportPNGData = function () {
 	                _this8.pixelInstance.exportAsImageData();
 	            };
+
+	            createBackgroundButton.setAttribute("id", "create-background-button");
+	            createBackgroundButton.appendChild(createBackgroundText);
+	            createBackgroundButton.addEventListener("click", this.createBackgroundLayer);
 
 	            csvExportButton.setAttribute("id", "csv-export-button");
 	            csvExportButton.appendChild(csvExportText);
@@ -3263,6 +3276,7 @@
 	            pngDataExportButton.appendChild(pngDataExportText);
 	            pngDataExportButton.addEventListener("click", this.exportPNGData);
 
+	            document.body.appendChild(createBackgroundButton);
 	            document.body.appendChild(csvExportButton);
 	            document.body.appendChild(pngExportButton);
 	            document.body.appendChild(rodanExportButton);


### PR DESCRIPTION
This way the background is optional and the user won't have to wait for the background to be regenerated each time they export to a different type; it is done once globally.

Also implemented a progress bar (same bar as exportToDataPNG and exportToCSV) so the user knows how long it takes until the background layer generation is completed without freezing the user interface (previously they'd have to open the console to see progress, and the UI would be frozen until it completed).

Note: In order to prevent UI lockup, needed to switch the implementation of the pixel iterator from the nested for loop to the doChunk() method that the OG pixel devs implemented.
Fixed my formatting to better match the style of the existing code.