### PR TITLE
Ignore background layer when exporting to CSV / image data PNG

### DIFF
--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -171,7 +171,9 @@ export class Export
             this.replaceLayerWithImageData(this.pixelInstance.core.getSettings().renderer._canvas, pngCanvas, this.pageIndex, layerCanvas, progressCanvas);
         });
 
-        this.layers.push(bgLayer);
+        if (document.getElementById("create-background-button").innerText === "Background Generated!") { 
+            this.layers.push(bgLayer);
+        }
     }
 
     /**
@@ -209,7 +211,9 @@ export class Export
             this.fillMatrix(layer, this.matrix, layerCanvas, progressCanvas);
         });
 
-        this.layers.push(bgLayer);
+        if (document.getElementById("create-background-button").innerText === "Background Generated!") { 
+            this.layers.push(bgLayer);
+        }
     }
 
     exportLayersToRodan ()

--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -129,9 +129,18 @@ export class Export
     /**
      * Creates a PNG for each layer where the pixels spanned by the layers are replaced by the actual image data
      * of the Diva page
+     * We need to remove the background layer since otherwise the generation isn't done properly because of the
+     * differing zoom mechanics for each layer. 
      */
     exportLayersAsImageData ()
     {
+        // Ignore background layer if generated, readd at end
+        var bgLayer;
+        if (document.getElementById("create-background-button").innerText === "Background Generated!") { 
+            bgLayer = this.layers.pop();
+            this.exportLayersCount--;
+        }
+
         this.dataCanvases = [];
 
         let height = this.pixelInstance.core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).height,
@@ -161,14 +170,25 @@ export class Export
             this.dataCanvases.push(pngCanvas);
             this.replaceLayerWithImageData(this.pixelInstance.core.getSettings().renderer._canvas, pngCanvas, this.pageIndex, layerCanvas, progressCanvas);
         });
+
+        this.layers.push(bgLayer);
     }
 
     /**
      * Creates a PNG for each layer where the pixels spanned by the layers are replaced by the actual image data
      * of the Diva page
+     * We need to remove the background layer since otherwise the generation isn't done properly because of the
+     * differing zoom mechanics for each layer.
      */
     exportLayersAsCSV ()
     {
+        // Ignore background layer if generated, readd at end
+        var bgLayer;
+        if (document.getElementById("create-background-button").innerText === "Background Generated!") { 
+            bgLayer = this.layers.pop();
+            this.exportLayersCount--;
+        }
+
         let core = this.pixelInstance.core,
             height = core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).height,
             width = core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).width;
@@ -188,6 +208,8 @@ export class Export
             layer.drawLayerInPageCoords(this.zoomLevel, layerCanvas, this.pageIndex);
             this.fillMatrix(layer, this.matrix, layerCanvas, progressCanvas);
         });
+
+        this.layers.push(bgLayer);
     }
 
     exportLayersToRodan ()

--- a/static/js/pixel.js
+++ b/static/js/pixel.js
@@ -2409,12 +2409,21 @@
 	        /**
 	         * Creates a PNG for each layer where the pixels spanned by the layers are replaced by the actual image data
 	         * of the Diva page
+	         * We need to remove the background layer since otherwise the generation isn't done properly because of the
+	         * differing zoom mechanics for each layer. 
 	         */
 
 	    }, {
 	        key: 'exportLayersAsImageData',
 	        value: function exportLayersAsImageData() {
 	            var _this3 = this;
+
+	            // Ignore background layer if generated, readd at end
+	            var bgLayer;
+	            if (document.getElementById("create-background-button").innerText === "Background Generated!") {
+	                bgLayer = this.layers.pop();
+	                this.exportLayersCount--;
+	            }
 
 	            this.dataCanvases = [];
 
@@ -2445,17 +2454,28 @@
 	                _this3.dataCanvases.push(pngCanvas);
 	                _this3.replaceLayerWithImageData(_this3.pixelInstance.core.getSettings().renderer._canvas, pngCanvas, _this3.pageIndex, layerCanvas, progressCanvas);
 	            });
+
+	            this.layers.push(bgLayer);
 	        }
 
 	        /**
 	         * Creates a PNG for each layer where the pixels spanned by the layers are replaced by the actual image data
 	         * of the Diva page
+	         * We need to remove the background layer since otherwise the generation isn't done properly because of the
+	         * differing zoom mechanics for each layer.
 	         */
 
 	    }, {
 	        key: 'exportLayersAsCSV',
 	        value: function exportLayersAsCSV() {
 	            var _this4 = this;
+
+	            // Ignore background layer if generated, readd at end
+	            var bgLayer;
+	            if (document.getElementById("create-background-button").innerText === "Background Generated!") {
+	                bgLayer = this.layers.pop();
+	                this.exportLayersCount--;
+	            }
 
 	            var core = this.pixelInstance.core,
 	                height = core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).height,
@@ -2476,6 +2496,8 @@
 	                layer.drawLayerInPageCoords(_this4.zoomLevel, layerCanvas, _this4.pageIndex);
 	                _this4.fillMatrix(layer, _this4.matrix, layerCanvas, progressCanvas);
 	            });
+
+	            this.layers.push(bgLayer);
 	        }
 	    }, {
 	        key: 'exportLayersToRodan',

--- a/static/js/pixel.js
+++ b/static/js/pixel.js
@@ -2455,7 +2455,9 @@
 	                _this3.replaceLayerWithImageData(_this3.pixelInstance.core.getSettings().renderer._canvas, pngCanvas, _this3.pageIndex, layerCanvas, progressCanvas);
 	            });
 
-	            this.layers.push(bgLayer);
+	            if (document.getElementById("create-background-button").innerText === "Background Generated!") {
+	                this.layers.push(bgLayer);
+	            }
 	        }
 
 	        /**
@@ -2497,7 +2499,9 @@
 	                _this4.fillMatrix(layer, _this4.matrix, layerCanvas, progressCanvas);
 	            });
 
-	            this.layers.push(bgLayer);
+	            if (document.getElementById("create-background-button").innerText === "Background Generated!") {
+	                this.layers.push(bgLayer);
+	            }
 	        }
 	    }, {
 	        key: 'exportLayersToRodan',


### PR DESCRIPTION
This is a possible fix to the [background layer zoom issue](https://github.com/DDMAL/pixel_wrapper/issues/19), since the exportToImageData/CSV aren't needed for CM yet still work standalone with Pixel.js. 

Now the background layer is only needed for exporting to highlights (so user can view their work) or submitting to Rodan (CM requires the highlights, **not** the image data). 

Ideally it'd be nice to have the background feature work with the image data as well, but there seems to be an ideology conflict with the background layer generation and the image data generation (this is explained in the issue linked above).

I'm guessing that the background layer functionality doesn't need to be a feature in the standalone Pixel.js, but only for the Rodan job. 