### PR TITLE
Ignore backgroundLayer when exporting to CSV/data

### DIFF
--- a/source/js/plugins/Pixel.js/source/export.js
+++ b/source/js/plugins/Pixel.js/source/export.js
@@ -28,7 +28,7 @@ export class Export
     createBackgroundLayer () 
     {
         // If generate background button has already been clicked, remove that background layer from layers
-        if (document.getElementById("create-background-button").innerText === "Background Generated!") { 
+        if (document.getElementById("create-background-button").value === "clicked") { 
             this.layers.pop();
             this.layersCount = this.layers.length;
         }
@@ -118,6 +118,7 @@ export class Export
                 backgroundLayer.drawLayer(0, backgroundLayer.getCanvas());
                 this.layers.push(backgroundLayer);  
                 document.getElementById("create-background-button").innerText = "Background Generated!";
+                document.getElementById("create-background-button").value = "clicked";
                 this.uiManager.destroyExportElements();
             }
         }
@@ -129,9 +130,18 @@ export class Export
     /**
      * Creates a PNG for each layer where the pixels spanned by the layers are replaced by the actual image data
      * of the Diva page
+     * We need to remove the background layer since otherwise the generation isn't done properly because of the
+     * differing zoom mechanics for each layer. 
      */
     exportLayersAsImageData ()
     {
+        // Ignore background layer if generated, readd at end
+        var bgLayer;
+        if (document.getElementById("create-background-button").value === "clicked") { 
+            bgLayer = this.layers.pop();
+            this.exportLayersCount--;
+        }
+
         this.dataCanvases = [];
 
         let height = this.pixelInstance.core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).height,
@@ -161,14 +171,27 @@ export class Export
             this.dataCanvases.push(pngCanvas);
             this.replaceLayerWithImageData(this.pixelInstance.core.getSettings().renderer._canvas, pngCanvas, this.pageIndex, layerCanvas, progressCanvas);
         });
+
+        if (document.getElementById("create-background-button").value === "clicked") { 
+            this.layers.push(bgLayer);
+        }
     }
 
     /**
      * Creates a PNG for each layer where the pixels spanned by the layers are replaced by the actual image data
      * of the Diva page
+     * We need to remove the background layer since otherwise the generation isn't done properly because of the
+     * differing zoom mechanics for each layer.
      */
     exportLayersAsCSV ()
     {
+        // Ignore background layer if generated, readd at end
+        var bgLayer;
+        if (document.getElementById("create-background-button").value === "clicked") { 
+            bgLayer = this.layers.pop();
+            this.exportLayersCount--;
+        }
+
         let core = this.pixelInstance.core,
             height = core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).height,
             width = core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).width;
@@ -188,6 +211,10 @@ export class Export
             layer.drawLayerInPageCoords(this.zoomLevel, layerCanvas, this.pageIndex);
             this.fillMatrix(layer, this.matrix, layerCanvas, progressCanvas);
         });
+
+        if (document.getElementById("create-background-button").value === "clicked") { 
+            this.layers.push(bgLayer);
+        }
     }
 
     exportLayersToRodan ()

--- a/static/js/pixel.js
+++ b/static/js/pixel.js
@@ -2305,7 +2305,7 @@
 	            var _this = this;
 
 	            // If generate background button has already been clicked, remove that background layer from layers
-	            if (document.getElementById("create-background-button").innerText === "Background Generated!") {
+	            if (document.getElementById("create-background-button").value === "clicked") {
 	                this.layers.pop();
 	                this.layersCount = this.layers.length;
 	            }
@@ -2398,6 +2398,7 @@
 	                    backgroundLayer.drawLayer(0, backgroundLayer.getCanvas());
 	                    this.layers.push(backgroundLayer);
 	                    document.getElementById("create-background-button").innerText = "Background Generated!";
+	                    document.getElementById("create-background-button").value = "clicked";
 	                    this.uiManager.destroyExportElements();
 	                }
 	            }
@@ -2409,12 +2410,21 @@
 	        /**
 	         * Creates a PNG for each layer where the pixels spanned by the layers are replaced by the actual image data
 	         * of the Diva page
+	         * We need to remove the background layer since otherwise the generation isn't done properly because of the
+	         * differing zoom mechanics for each layer. 
 	         */
 
 	    }, {
 	        key: 'exportLayersAsImageData',
 	        value: function exportLayersAsImageData() {
 	            var _this3 = this;
+
+	            // Ignore background layer if generated, readd at end
+	            var bgLayer;
+	            if (document.getElementById("create-background-button").value === "clicked") {
+	                bgLayer = this.layers.pop();
+	                this.exportLayersCount--;
+	            }
 
 	            this.dataCanvases = [];
 
@@ -2445,17 +2455,30 @@
 	                _this3.dataCanvases.push(pngCanvas);
 	                _this3.replaceLayerWithImageData(_this3.pixelInstance.core.getSettings().renderer._canvas, pngCanvas, _this3.pageIndex, layerCanvas, progressCanvas);
 	            });
+
+	            if (document.getElementById("create-background-button").value === "clicked") {
+	                this.layers.push(bgLayer);
+	            }
 	        }
 
 	        /**
 	         * Creates a PNG for each layer where the pixels spanned by the layers are replaced by the actual image data
 	         * of the Diva page
+	         * We need to remove the background layer since otherwise the generation isn't done properly because of the
+	         * differing zoom mechanics for each layer.
 	         */
 
 	    }, {
 	        key: 'exportLayersAsCSV',
 	        value: function exportLayersAsCSV() {
 	            var _this4 = this;
+
+	            // Ignore background layer if generated, readd at end
+	            var bgLayer;
+	            if (document.getElementById("create-background-button").value === "clicked") {
+	                bgLayer = this.layers.pop();
+	                this.exportLayersCount--;
+	            }
 
 	            var core = this.pixelInstance.core,
 	                height = core.publicInstance.getPageDimensionsAtZoomLevel(this.pageIndex, this.zoomLevel).height,
@@ -2476,6 +2499,10 @@
 	                layer.drawLayerInPageCoords(_this4.zoomLevel, layerCanvas, _this4.pageIndex);
 	                _this4.fillMatrix(layer, _this4.matrix, layerCanvas, progressCanvas);
 	            });
+
+	            if (document.getElementById("create-background-button").value === "clicked") {
+	                this.layers.push(bgLayer);
+	            }
 	        }
 	    }, {
 	        key: 'exportLayersToRodan',


### PR DESCRIPTION
Temporarily remove the backgroundLayer as a layer when exporting to imageData/CSV since it isn't needed for those export types and has a zoom compatibility issue.
