### PR TITLE
Include selectRegionLayer when exporting to Rodan

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,15 @@ Here are some user-level instructions on adding a pixel.js job in RODAN.
 - Create a new workflow, or select an existing one.
 - Double-click workflow -> workflow header tab -> add job
 - Find `Diva - Pixel.js` -> Add
-- Double-click red input square to select background image from resources (you must pre-upload resources, select the resource section on the left to do so)
+- Double-click red input square to select your image from resources (you must pre-upload resources, select the resource section on the left to do so)
 - Choose png or tiff resource -> add -> input square should be green now
 - Workflow header tab -> run
+
+#### Classification 
+- You must create however many layers that you wish to classify as the input ports.
+  - Do this by right clicking on the Pixel job, clicking on ports, and adding/deleting input ports as needed.
+- There must be two more output ports than input ports.
+  - For example, if you have `Layers {1, 2, 3}` as input ports, then you must have `Layers {0, 1, 2, 3, 4}` as output ports. `Layer 0` is enabled by default.
 
 ## Making changes to the pixel_wrapper source code
 Sometimes changes need to be done to the wrapper code found in `source/js/plugins/pixel-wrapper.js`, or the `Pixel.js` source code in `source/js/plugins/Pixel.js`. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pixel_wrapper
+# Pixel Wrapper
 
 A wrapper to run [```Pixel.js```](https://github.com/DDMAL/Pixel.js) on top of [```Diva.js```](https://github.com/DDMAL/diva.js) as a job in the workflow builder [```Rodan```](https://github.com/DDMAL/Rodan)
 
@@ -58,11 +58,14 @@ Here are some user-level instructions on adding a pixel.js job in RODAN.
 - Choose png or tiff resource -> add -> input square should be green now
 - Workflow header tab -> run
 
-#### Classification 
+### Setting Up the Ports
 - You must create however many layers that you wish to classify as the input ports.
   - Do this by right clicking on the Pixel job, clicking on ports, and adding/deleting input ports as needed.
-- There must be two more output ports than input ports.
-  - For example, if you have `Layers {1, 2, 3}` as input ports, then you must have `Layers {0, 1, 2, 3, 4}` as output ports. `Layer 0` is enabled by default.
+  - For example, if you're working with 3 layers (music symbols, text, and staff lines), then create three input ports.
+- There must be two more output ports than input ports. 
+  - This is because one port is reserved for the auto-generated *Background Layer* (the negative of the classified layers combined), and another is reserved for the *Select Regions Layer* (a mask of the user-verified portions of the image). 
+  - Ensure that your output ports are in incremental order (ie. do not skip from layer 1 to layer 5).
+- For example, if you have `Layers {1, 2, 3}` as input ports, then you must have `Layers {0, 1, 2, 3, 4}` as output ports. `Layer 0` is already enabled by default, so you'd just need to enable the other 4.
 
 ## Making changes to the pixel_wrapper source code
 Sometimes changes need to be done to the wrapper code found in `source/js/plugins/pixel-wrapper.js`, or the `Pixel.js` source code in `source/js/plugins/Pixel.js`. 

--- a/source/js/plugins/pixel-wrapper.js
+++ b/source/js/plugins/pixel-wrapper.js
@@ -140,6 +140,8 @@ export class PixelWrapper
     {
         console.log("Exporting!");
 
+        this.layers.push(this.selectRegionLayer);
+
         let count = this.layers.length;
         let urlList = [];
 
@@ -148,7 +150,7 @@ export class PixelWrapper
             console.log(layer.layerId + " " + layer.layerName);
 
             let dataURL = layer.getCanvas().toDataURL();
-            urlList[layer.layerId] = dataURL; 
+            urlList.push(dataURL); 
             count -= 1;
                 if (count === 0)
                 {
@@ -171,7 +173,7 @@ export class PixelWrapper
      */
     createBackgroundLayer () 
     {
-        // Don't export selectRegionLayer to Rodan
+        // Don't consider selectRegionLayer for background generation
         this.layers.shift();
 
         // NOTE: this backgroundLayer and the original background (image) both have layerId 0, but 

--- a/static/js/pixel.js
+++ b/static/js/pixel.js
@@ -1332,6 +1332,8 @@
 	        value: function exportLayersToRodan() {
 	            console.log("Exporting!");
 
+	            this.layers.push(this.selectRegionLayer);
+
 	            var count = this.layers.length;
 	            var urlList = [];
 
@@ -1340,7 +1342,7 @@
 	                console.log(layer.layerId + " " + layer.layerName);
 
 	                var dataURL = layer.getCanvas().toDataURL();
-	                urlList[layer.layerId] = dataURL;
+	                urlList.push(dataURL);
 	                count -= 1;
 	                if (count === 0) {
 	                    console.log(urlList);
@@ -1370,7 +1372,7 @@
 	        value: function createBackgroundLayer() {
 	            var _this2 = this;
 
-	            // Don't export selectRegionLayer to Rodan
+	            // Don't consider selectRegionLayer for background generation
 	            this.layers.shift();
 
 	            // NOTE: this backgroundLayer and the original background (image) both have layerId 0, but 

--- a/wrapper.py
+++ b/wrapper.py
@@ -219,6 +219,13 @@ class PixelInteractive(RodanTask):
             'maximum': 1,
             'is_list': False
         },
+        {
+            'name': 'rgba PNG - Layer 8 Output',
+            'resource_types': ['image/rgba+png'],
+            'minimum': 0,
+            'maximum': 1,
+            'is_list': False
+        },
     ]
 
     def get_my_interface(self, inputs, settings):


### PR DESCRIPTION
Will always be the last layer in the list of layers (so last output port also). 

The user has to create 1 more output port than input port. It was difficult to have this as a mandatory port since it has ID -1, and I couldn't make an output port with layer ID -1 properly 

Updated README with instructions

