### PR TITLE
Wait on POST request to finish before closing

### DIFF
--- a/source/js/plugins/pixel-wrapper.js
+++ b/source/js/plugins/pixel-wrapper.js
@@ -191,13 +191,24 @@ export class PixelWrapper
                     console.log(urlList);
                     console.log("done");
 
-                    $.ajax({url: '', type: 'POST', data: JSON.stringify({'user_input': urlList}), contentType: 'application/json'});
+                    $.ajax({
+                        url: '',
+                        type: 'POST',
+                        data: JSON.stringify({'user_input': urlList}),
+                        contentType: 'application/json',
+                        success: () => {
+                            setTimeout(function(){ alert("Submission successful! Click OK to exit Pixel.js."); }, 1000);
+                            setTimeout(function(){ window.close(); }, 1200);
+                        },
+                        error: (jqXHR, textStatus, errorThrown) => {
+                            console.log(jqXHR);
+                            console.log(textStatus);
+                            console.log(errorThrown);
+                            alert("An error occurred: " + errorThrown);
+                        }
+                    });
                 }
         });
-
-        // Alert and close Pixel after submitting
-        setTimeout(function(){ alert("Submission successful! Click OK to exit Pixel.js."); }, 1000);
-        setTimeout(function(){ window.close(); }, 1200);
     }
 
     /**


### PR DESCRIPTION
Sometimes this request takes a long time depending on file size/internet
connection. Do not prompt immediately after sending the request but wait
for it to succeed. If not, provide an error.