### PR TITLE
Submit entire background if user selects nothing

### DIFF
--- a/source/js/plugins/pixel-wrapper.js
+++ b/source/js/plugins/pixel-wrapper.js
@@ -228,7 +228,8 @@ export class PixelWrapper
             this.pixelInstance, 0.5, this.pixelInstance.actions);
         console.log(this.selectRegionLayer.shapes, this.selectRegionLayer.shapes.length);
 
-        // Alert and return if user hasn't created a selection region
+        // Alert and return if user hasn't created a selection region.
+        // Ask for permission to select the entire bacgkround layer for them
         if (this.selectRegionLayer.shapes.length === 0)
         {
             if(confirm("You haven't created any select regions. Press OK to select the entire background region.")) {

--- a/source/js/plugins/pixel-wrapper.js
+++ b/source/js/plugins/pixel-wrapper.js
@@ -226,6 +226,20 @@ export class PixelWrapper
         // this backgroundLayer is only created upon submitting (so no conflicts)
         let backgroundLayer = new Layer(0, new Colour(242, 0, 242, 1), "Background Layer",
             this.pixelInstance, 0.5, this.pixelInstance.actions);
+        console.log(this.selectRegionLayer.shapes, this.selectRegionLayer.shapes.length);
+
+        // Alert and return if user hasn't created a selection region
+        if (this.selectRegionLayer.shapes.length === 0)
+        {
+            if(confirm("You haven't created any select regions. Press OK to select the entire background region.")) {
+                let rect = new Rectangle(new Point(0,0,this.pageIndex),this.maxWidth,this.maxHeight,"add");
+                this.selectRegionLayer.addShapeToLayer(rect);
+            }
+            else {
+                this.layers.unshift(this.selectRegionLayer);
+                return;
+            }
+        }
 
         // Add select regions to backgroundLayer
         this.selectRegionLayer.shapes.forEach((shape) =>
@@ -245,13 +259,7 @@ export class PixelWrapper
         });
         backgroundLayer.drawLayer(this.maxZoom, backgroundLayer.getCanvas());
 
-        // Alert and return if user hasn't created a selection region
-        if (this.selectRegionLayer.shapes.length === 0)
-        {
-            alert("You haven't created any select regions!");
-            this.layers.unshift(this.selectRegionLayer);
-            return;
-        }
+        
 
         // Instantiate progress bar
         // this.uiManager.createExportElements(this);


### PR DESCRIPTION
Address feature request raised in this [issue](https://github.com/DDMAL/Pixel.js/issues/265).

Before, when the user attempted to submit to rodan without selecting part of the background, pixel wrapping would alert them about this and force them to do a selection (the user could easily bypass this by accident but this bug is to be addressed in the pixel repo).

Now attempting to submit an empty background layer causes pixel-wrapping to automatically submit the entire background after asking for the user's permission.